### PR TITLE
Add human-time command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# README.rst is generated from README.md
+README.rst
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ sourcing them now, I'm hoping to not have to write them again.
 
 Everything in this repository is Apache 2.0 licensed.
 
+# Included Commands
+
+## human-time
+
+Takes a value in seconds either from stdin or as arg 1 and converts it to a more meat-friendly format using the humanTime function.
+
+`human-time 1234` will print "20 minutes, 34 seconds"
+
 # Included functions
 
 ## logrus.cli
@@ -69,6 +77,10 @@ def fooDriver():
   check_call([command] + args)
 
 ```
+
+### humanTime(seconds)
+
+Takes a value in seconds, returns it in meat-friendly format. `humanFriendlyTime(8675309)` would return "100 days 9 hours 48 minutes 29 seconds".
 
 ### isProgram(name)
 

--- a/logrus/cli.py
+++ b/logrus/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2015 Joe Block <jpb@unixorn.net>
+# Copyright 2015-2017 Joe Block <jpb@unixorn.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/logrus/time.py
+++ b/logrus/time.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# Copyright 2017 Joe Block <jpb@unixorn.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Time utility functions
+'''
+import sys
+from dateutil.relativedelta import relativedelta as deltaTime
+
+def humanTime(seconds):
+  '''
+  Convert seconds to something more human-friendly
+  '''
+  intervals = ['days', 'hours', 'minutes', 'seconds']
+  x = deltaTime(seconds=seconds)
+  return ' '.join('{} {}'.format(getattr(x, k), k) for k in intervals if getattr(x, k))
+
+
+def humanTimeConverter():
+  '''
+  Cope whether we're passed a time in seconds on the command line or via stdin
+  '''
+  if len(sys.argv) == 2:
+    print humanFriendlyTime(seconds=int(sys.argv[1]))
+  else:
+    for line in sys.stdin:
+      print humanFriendlyTime(int(line))
+      sys.exit(0)
+
+
+if __name__ == '__main__':
+  print 'This is a library, not a stand alone script'
+  sys.exit(1)

--- a/logrus/utils.py
+++ b/logrus/utils.py
@@ -68,8 +68,7 @@ def mkdir_p(path):
   '''
   Mimic `mkdir -p` since os module doesn't provide one.
 
-  :param str name: Name of program to search for
-
+  :param str path: directory to create
   '''
   try:
     os.makedirs(path)
@@ -88,7 +87,7 @@ def systemCall(command):
   :param str command: Command to run
   :rtype: str
   '''
-  assert isinstance(command, basestring), ("command must be a string but is %r" % command)
+  assert isinstance(command, basestring), ("command must be a string but is type %r" % command)
 
   p = subprocess.Popen([command], stdout=subprocess.PIPE, shell=True)
   return p.stdout.read()

--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,14 @@ def system_call(command):
   Run a command and return stdout.
 
   Would be better to use subprocess.check_output, but this works on 2.6,
-  which is still the system Python on CentOS 7.'''
+  which is still the system Python on CentOS 7.
+  '''
   p = subprocess.Popen([command], stdout=subprocess.PIPE, shell=True)
   return p.stdout.read()
 
 
 name = 'logrus'
-version = "0.1.%s" % (system_call('git rev-list HEAD --count').strip())
+version = "0.2.%s" % (system_call('git rev-list HEAD --count').strip())
 
 
 class CleanCommand(Command):
@@ -80,6 +81,11 @@ setup(
   ],
   cmdclass={
     "clean": CleanCommand,
+  },
+  entry_points={
+    "console_scripts": [
+      "human-time = %s.time:humanTimeConverter" % name,
+    ]
   },
   keywords=["devops", "utility"],
 )


### PR DESCRIPTION
`human-time` takes a value in seconds and prints it in meat-friendly
format.

`human-time 1234` prints "20 minutes, 34 seconds", for example.